### PR TITLE
FIX: ESC fires keypress event on IE, unlike other browsers.

### DIFF
--- a/teletext-editor.html
+++ b/teletext-editor.html
@@ -1037,6 +1037,10 @@ function keypress(event) {
 	// Code 0 means there was simply no keypress.
 	if ( code == 0 ) { return; }
 
+	// On Internet Explorer, ESC key triggers keypress too,
+	// so return since we've already handled ESC in keydown
+	if ( code == 27 ) { return; }
+
 	// Stop Firefox bringing up a search box when the apostrophe or 
 	// slash key is pressed.
 	if ( code == 39 ) { event.preventDefault(); }


### PR DESCRIPTION
This closes #4. Tested on IE, Firefox and Chrome, on Windows 8.1.